### PR TITLE
KEH-921-3 - Update branch and repo names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,9 @@ name: CI
 
 on: # yamllint disable-line rule:truthy
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 concurrency:
   group: "${{ github.head_ref || github.ref }}-${{ github.workflow }}"

--- a/.github/workflows/deploy_mkdocs.yml
+++ b/.github/workflows/deploy_mkdocs.yml
@@ -1,10 +1,9 @@
-# A GitHub Actions workflow to deploy MkDocs documentation to GitHub Pages on push to the master or main branch.
+# A GitHub Actions workflow to deploy MkDocs documentation to GitHub Pages on push to the main branch.
 ---
 name: Deploy MkDocs
 on:
   push:
     branches:
-      - master 
       - main
 permissions:
   contents: write

--- a/.gitignore
+++ b/.gitignore
@@ -53,10 +53,6 @@ override.tf.json
 .terraformrc
 terraform.rc
 
-# Ignore the terraform/service prority calc
-terraform/dashboard/highest_priority.txt
-terraform/dashboard/highest_alb_listener_priority.txt
-
 .env
 
 # Ignore the .DS_Store file created by macOS

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ This project uses Pytest for testing. The tests can be found in the `tests` fold
 
 To run all tests, use `make test`.
 
-On pull request or push to the `master` branch, the tests will automatically run. The workflow will fail if any tests fail, or if test coverage is below 95%. 
+On pull request or push to the `main` branch, the tests will automatically run. The workflow will fail if any tests fail, or if test coverage is below 95%. 
 
 The related workflow can be found in `.github/workflows/ci.yml`.
 
@@ -91,7 +91,7 @@ lint  ## Run Python linters without fixing.
 lint-apply ## Run black and ruff with auto-fix, and Pylint.
 ```
 
-On pull request or push to the `master` branch, `make lint` will automatically run to check code quality, failing if there are any issues. It is up to the developer to apply fixes. 
+On pull request or push to the `main` branch, `make lint` will automatically run to check code quality, failing if there are any issues. It is up to the developer to apply fixes. 
 
 The related workflow can be found in `.github/workflows/ci.yml`.
 
@@ -400,7 +400,7 @@ If you wish to set a pipeline for another branch without checking out, you can r
 ./concourse/scripts/set_pipeline.sh github-copilot-usage-lambda <branch_name>
 ```
 
-If the branch you are deploying is `main` or `master`, it will trigger a deployment to the `sdp-prod` environment. To set the ECR image tag, you must draft a GitHub release pointing to the latest release of the `main/master` branch that has a tag in the form of `vX.Y.Z.` Drafting up a release will automatically deploy the latest version of the `main/master` branch with the associated release tag, but you can also manually trigger a build through the Concourse UI or the terminal prompt.
+If the branch you are deploying is `main`, it will trigger a deployment to the `sdp-prod` environment. To set the ECR image tag, you must draft a GitHub release pointing to the latest release of the `main` branch that has a tag in the form of `vX.Y.Z.` Drafting up a release will automatically deploy the latest version of the `main` branch with the associated release tag, but you can also manually trigger a build through the Concourse UI or the terminal prompt.
 
 ## Triggering a pipeline
 Once the pipeline has been set, you can manually trigger a build on the Concourse UI, or run the following command:

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,12 +1,12 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: github-copilot-usage-dashboard
+  name: github-copilot-usage-lambda
   annotations:
-    github.com/project-slug: ONS-Innovation/github-copilot-usage-dashboard
+    github.com/project-slug: ONS-Innovation/github-copilot-usage-lambda
   links:
-    - url: https://ons-innovation.github.io/github-copilot-usage-dashboard
-      title: Copilot Usage Dashboard Documentation  
+    - url: https://ons-innovation.github.io/github-copilot-usage-lambda
+      title: Copilot Usage Lambda Documentation  
 spec:
   type: service
   lifecycle: production

--- a/concourse/ci.yml
+++ b/concourse/ci.yml
@@ -3,7 +3,7 @@ resources:
   type: git
   icon: github
   source:
-    uri: https://github.com/ONS-Innovation/github-copilot-usage-dashboard
+    uri: https://github.com/ONS-Innovation/github-copilot-usage-lambda
     username: ((github_access_token))
     password: x-oauth-basic
     branch: ((branch))
@@ -38,7 +38,7 @@ jobs:
           apk add --no-cache aws-cli podman jq iptables curl
 
           if [[ "((env))" == "prod" ]]; then
-            tag=$(curl "https://api.github.com/repos/ONS-Innovation/github-copilot-usage-dashboard/releases" | jq -r '.[0].tag_name')
+            tag=$(curl "https://api.github.com/repos/ONS-Innovation/github-copilot-usage-lambda/releases" | jq -r '.[0].tag_name')
             export tag
           else
             export tag=((tag))
@@ -69,7 +69,7 @@ jobs:
           apk add --no-cache jq curl
 
           if [[ "((env))" == "prod" ]]; then
-            tag=$(curl "https://api.github.com/repos/ONS-Innovation/github-copilot-usage-dashboard/releases" | jq -r '.[0].tag_name')
+            tag=$(curl "https://api.github.com/repos/ONS-Innovation/github-copilot-usage-lambda/releases" | jq -r '.[0].tag_name')
             export tag
           else 
             export tag=((tag))

--- a/concourse/scripts/set_pipeline.sh
+++ b/concourse/scripts/set_pipeline.sh
@@ -11,7 +11,7 @@ else
     branch=$(git rev-parse --abbrev-ref HEAD)
 fi
 
-if [[ ${branch} == "main" || ${branch} == "master" ]]; then
+if [[ ${branch} == "main" ]]; then
     env="prod"
 else
     env="dev"

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,4 +35,4 @@ This section gathers data from AWS S3. The Copilot usage endpoints have a limita
 
 ## Getting Started
 
-To setup and use the project, please refer to the [README](https://github.com/ONS-Innovation/github-copilot-usage-dashboard/blob/main/README.md).
+To setup and use the project, please refer to the [README](https://github.com/ONS-Innovation/github-copilot-usage-lambda/blob/main/README.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,4 +35,4 @@ This section gathers data from AWS S3. The Copilot usage endpoints have a limita
 
 ## Getting Started
 
-To setup and use the project, please refer to the [README](https://github.com/ONS-Innovation/github-copilot-usage-dashboard/blob/master/README.md).
+To setup and use the project, please refer to the [README](https://github.com/ONS-Innovation/github-copilot-usage-dashboard/blob/main/README.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
-site_name: GitHub Copilot Usage Dashboard
+site_name: GitHub Copilot Usage Lambda
 
-repo_url: https://github.com/ONS-Innovation/github-copilot-usage-dashboard
-repo_name: GitHub Copilot Usage Dashboard
+repo_url: https://github.com/ONS-Innovation/github-copilot-usage-lambda
+repo_name: GitHub Copilot Usage Lambda
 
 nav:
   - Home: 'index.md'


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

### What

Following the repo clean up, the default branch has been renamed to 'main' from 'master', and the repo name to 'lambda' from 'dashboard'.

### Testing

Have any new tests been added as part of this issue? If not, try to explain why test coverage is not needed here.

- [ ] Yes
- [x] No
Please write a brief description of why test coverage is not necessary here.
- [ ] Not as part of this ticket. (Could be done at a later point)

### Documentation

Has any new documentation been written as part of this issue? We should try to keep documentation up to date 
as new code is added, rather than leaving it for the future.

- [ ] Yes
- [x] No
Please write a brief description of why documentation is not necessary here.
- [ ] Not as part of this ticket. (Could be done at a later point)

### Related issues

KEH-921

### How to review

Keyword search the codebase for any old names in the wrong place.