### PR TITLE
KEH-1236 | Bug Fix: copilot_team.json logic

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -379,7 +379,7 @@ def handler(event: dict, context) -> str:  # pylint: disable=unused-argument
     return "Github Data logging is now complete."
 
 
-# Dev Only
-# Uncomment the following line to run the script locally
-if __name__ == "__main__":
-    handler(None, None)
+# # Dev Only
+# # Uncomment the following line to run the script locally
+# if __name__ == "__main__":
+#     handler(None, None)

--- a/src/main.py
+++ b/src/main.py
@@ -73,16 +73,40 @@ def get_copilot_team_date(gh: github_api_toolkit.github_interface, page: int) ->
         usage_data = gh.get(f"/orgs/{org}/team/{team['name']}/copilot/metrics")
 
         if not isinstance(usage_data, Response):
-            logger.error("Unexpected response type: %s", type(usage_data))
+
+            # If the response is not a Response object, no copilot data is available for this team
+            # We can then skip this team
+            # We don't log this as an error, as it is expected that some teams may not have Copilot data and it'd be too noisy
+
             continue
-        copilot_teams.append(
-            {
-                "name": team.get("name", ""),
-                "slug": team.get("slug", ""),
-                "description": team.get("description", ""),
-                "url": team.get("html_url", ""),
-            }
-        )
+
+        # If the response has data, append the team to the list
+        # If there is no data, .json() will return an empty list
+        if usage_data.json():
+
+            team_name = team.get("name", "")
+            team_slug = team.get("slug", "")
+            team_description = team.get("description", "")
+            team_html_url = team.get("html_url", "")
+
+            logger.info(
+                "Team %s has Copilot data",
+                extra={
+                    "team_name": team_name,
+                    "team_slug": team_slug,
+                    "team_description": team_description,
+                    "team_html_url": team_html_url,
+                }
+            )
+
+            copilot_teams.append(
+                {
+                    "name": team_name,
+                    "slug": team_slug,
+                    "description": team_description,
+                    "url": team_html_url,
+                }
+            )
 
     return copilot_teams
 
@@ -355,7 +379,7 @@ def handler(event: dict, context) -> str:  # pylint: disable=unused-argument
     return "Github Data logging is now complete."
 
 
-# # Dev Only
-# # Uncomment the following line to run the script locally
-# if __name__ == "__main__":
-#     handler(None, None)
+# Dev Only
+# Uncomment the following line to run the script locally
+if __name__ == "__main__":
+    handler(None, None)

--- a/src/main.py
+++ b/src/main.py
@@ -74,9 +74,10 @@ def get_copilot_team_date(gh: github_api_toolkit.github_interface, page: int) ->
 
         if not isinstance(usage_data, Response):
 
-            # If the response is not a Response object, no copilot data is available for this team
+            # If the response is not a Response object, no copilot data is available for this team
             # We can then skip this team
-            # We don't log this as an error, as it is expected that some teams may not have Copilot data and it'd be too noisy
+
+            # We don't log this as an error, as it is expected and it'd be too noisy within logs
 
             continue
 
@@ -96,7 +97,7 @@ def get_copilot_team_date(gh: github_api_toolkit.github_interface, page: int) ->
                     "team_slug": team_slug,
                     "team_description": team_description,
                     "team_html_url": team_html_url,
-                }
+                },
             )
 
             copilot_teams.append(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -331,9 +331,6 @@ class TestGetCopilotTeamDate:
         with caplog.at_level("ERROR"):
             result = get_copilot_team_date(gh, 1)
             assert result == []
-            assert any(
-                "Unexpected response type" in record.getMessage() for record in caplog.records
-            )
 
     @patch("src.main.org", "test-org")
     def test_get_copilot_team_date_empty_teams(self):


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

### What

Following the repository refactor, logic for figuring out which teams had copilot data became incorrect. This caused `copilot_teams.json` to record teams with no copilot data.

To fix this, the logic has been updated so that the lambda checks if the json response from the GitHub API is empty in addition to its original checks.

This PR also includes some minor logging improvements to reduce noise in CloudWatch.

This has been completed in a pair with @smstone0.

### Testing

Have any new tests been added as part of this issue? If not, try to explain why test coverage is not needed here.

- [ ] Yes
- [x] No
Please write a brief description of why test coverage is not necessary here.
- [ ] Not as part of this ticket. (Could be done at a later point)

### Documentation

Has any new documentation been written as part of this issue? We should try to keep documentation up to date 
as new code is added, rather than leaving it for the future.

- [ ] Yes
- [x] No
Please write a brief description of why documentation is not necessary here.
- [ ] Not as part of this ticket. (Could be done at a later point)

### Related issues

KEH-1236 (Jira)

### How to review

- Pull down, setup and run the lambda locally on sdp-dev.
- Once the lambda has run, verify that `copilot_teams.json` in S3 is correct (should have around 20~ teams).