### PR TITLE
fix(lint): address temporary linting exceptions

### DIFF
--- a/.checkov.yml
+++ b/.checkov.yml
@@ -21,6 +21,7 @@ skip-check:
   # SPP use the same pattern so it's not a concern for us
   - CKV_AWS_382
 
-  # These ignores are TEMPORARY. They will be resolved in the future.
-  - CKV_AWS_108
+  # Ignore adding code-signing to Lambda.
+  # It is not needed here since our Lambda functions use container
+  # images over uploading .zip files for layers.
   - CKV_AWS_272

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -39,7 +39,9 @@ data "aws_iam_policy_document" "lambda_logging" {
       "logs:PutLogEvents",
     ]
 
-    resources = ["arn:aws:logs:*:*:*"] #trivy:ignore:AVD-AWS-0057
+    resources = [
+      "${aws_cloudwatch_log_group.loggroup.arn}:*"
+    ]
   }
 }
 
@@ -70,7 +72,7 @@ data "aws_iam_policy_document" "lambda_secret_manager_policy" {
     ]
 
     resources = [
-      "*"
+      "arn:aws:secretsmanager:*:*:secret:${var.aws_secret_name}*"
     ]
   }
 }


### PR DESCRIPTION
## Overview

This PR address temporary linting exceptions.

- CKV_AWS_108: Limited IAM to specific resources.
- CKV_AWS_272: Code signing can be ignored since our lambdas use container images.